### PR TITLE
fix function build_mail_to_list in mailer handler

### DIFF
--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -62,7 +62,7 @@ class Mailer < Sensu::Handler
   def build_mail_to_list
     json_config = config[:json_config] || 'mailer'
     mail_to = @event['client']['mail_to'] || settings[json_config]['mail_to']
-    if settings[json_config].key?('subscriptions')
+    if settings[json_config].key?('subscriptions') && @event['check']['subscribers']
       @event['check']['subscribers'].each do |sub|
         if settings[json_config]['subscriptions'].key?(sub)
           mail_to << ", #{settings[json_config]['subscriptions'][sub]['mail_to']}"


### PR DESCRIPTION
Issue:
```
{"timestamp":"2015-06-24T21:32:47.919172+0000","level":"info","message":"handler output","handler":{"command":"/opt/sensu/embedded/bin/ruby /etc/sensu/handlers/mailer.rb","type":"pipe","severities":["ok","warning","critical","unknown"],"name":"mailer"},"output":["/etc/sensu/handlers/mailer.rb:66:in `build_mail_to_list': undefined method `each' for nil:NilClass (NoMethodError)\n","\tfrom /etc/sensu/handlers/mailer.rb:78:in `handle'\n","\tfrom /opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-1.1.0/lib/sensu-handler.rb:55:in `block in <class:Handler>'\n"]}
```

subscribers param is not required in standalone mode:
> https://sensuapp.org/docs/latest/checks#definition-attributes