### PR TITLE
Use correct Mailgun gem

### DIFF
--- a/bin/handler-mailer-mailgun.rb
+++ b/bin/handler-mailer-mailgun.rb
@@ -29,7 +29,7 @@
 #   for details.
 
 require 'sensu-handler'
-require 'mailgun'
+require 'mailgun-ruby'
 require 'timeout'
 
 class Mailer < Sensu::Handler

--- a/sensu-plugins-mailer.gemspec
+++ b/sensu-plugins-mailer.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'aws',               '2.10.2'
   s.add_runtime_dependency 'mail',              '2.6.3'
-  s.add_runtime_dependency 'mailgun',           '0.8'
+  s.add_runtime_dependency 'mailgun-ruby',      '1.0.3'
   s.add_runtime_dependency 'sensu-plugin',      '1.2.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'


### PR DESCRIPTION
Using old "mailgun" gem caused error at runtime. Switching to "mailgun-ruby" corrects this. Comment in bin/handler-mailer-mailgun.rb reenforces the idea that the code was written for "mailgun-ruby" initially.