### PR TITLE
Password replacing code handles option argument only.

### DIFF
--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -89,8 +89,8 @@ class Mailer < Sensu::Handler
     smtp_authentication = settings[json_config]['smtp_authentication'] || :plain
     smtp_enable_starttls_auto = settings[json_config]['smtp_enable_starttls_auto'] == 'false' ? false : true
     # try to redact passwords from output and command
-    output = "#{@event['check']['output']}".gsub(/(-p|-P|--password)\s*\S+/, '\1 <password redacted>')
-    command = "#{@event['check']['command']}".gsub(/(-p|-P|--password)\s*\S+/, '\1 <password redacted>')
+    output = "#{@event['check']['output']}".gsub(/(\s-p|\s-P|\s--password)(\s*\S+)/, '\1 <password omitted>')
+    command = "#{@event['check']['command']}".gsub(/(\s-p|\s-P|\s--password)(\s*\S+)/, '\1 <password omitted>')
 
     playbook = "Playbook:  #{@event['check']['playbook']}" if @event['check']['playbook']
     body = <<-BODY.gsub(/^\s+/, '')


### PR DESCRIPTION
Previously the following matched twice, which is wrong.

/some/path/check-pgsql.rb -u user -p pass -c 1 -C1

The fixed code now only matches the password option.
Additionally improved wording of substitute IMHO.