### PR TITLE
Add template support for email message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased][unreleased]
--nothing
+### Added
+- Ability to use custom ERB template for mail message
+- Ability to specify a custom timeout interval for sending mail
 
 ## [0.0.2] - [2015-07-14]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ The following three configuration variables must be set if you want mailer to us
 
 There is an optional subscriptions hash which can be added to your mailer.json file.  This subscriptions hash allows you to define individual mail_to addresses for a given subscription.  When the mailer handler runs it will check the clients subscriptions and build a mail_to string with the default mailer.mail_to address as well as any subscriptions the client subscribes to where a mail_to address is found.  There can be N number of hashes inside of subscriptions but the key for a given hash inside of subscriptions must match a subscription name. 
 
+Optionally, you can specify your own ERB template file to use for the message
+body.  The order of precedence for templates is: command-line argument (-t),
+client config called "template", the mailer handler config, default.
+
 ```json
 {
   "mailer": {
@@ -32,6 +36,7 @@ There is an optional subscriptions hash which can be added to your mailer.json f
     "smtp_address": "smtp.example.org",
     "smtp_port": "25",
     "smtp_domain": "example.org",
+    "template": "/optional/path/to/template.erb",
     "subscriptions": {
         "subscription_name": {
             "mail_to": "teamemail@example.com"

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -74,7 +74,7 @@ class Mailer < Sensu::Handler
     end
   end
 
-  def get_content_type
+  def parse_content_type
     if config[:content_type]
       use = config[:content_type]
     elsif @event['check']['content_type']
@@ -143,7 +143,7 @@ class Mailer < Sensu::Handler
   def handle
     json_config = config[:json_config]
     body = build_body
-    content_type = get_content_type
+    content_type = parse_content_type
     mail_to = build_mail_to_list
     mail_from =  settings[json_config]['mail_from']
     reply_to = settings[json_config]['reply_to'] || mail_from

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -50,8 +50,7 @@ class Mailer < Sensu::Handler
          description: 'Content-type of message',
          short: '-c ContentType',
          long: '--content_type ContentType',
-         required: false,
-         default: 'plain'
+         required: false
 
   def short_name
     @event['client']['name'] + '/' + @event['check']['name']

--- a/sensu-plugins-mailer.gemspec
+++ b/sensu-plugins-mailer.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mail',              '2.6.3'
   s.add_runtime_dependency 'mailgun-ruby',      '1.0.3'
   s.add_runtime_dependency 'sensu-plugin',      '1.2.0'
+  s.add_runtime_dependency 'erubis',            '2.7.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
This commit adds the ability to use a custom template (ERB) for the
e-mail message with the `handler-mailer.rb` handler.

The template can be specified a few different ways.  In order of
precedence of what will be used, if specified:
  1. command-line argument (-t) to handler
  2. key in event (@event['check']['template']
  3. handler's global config (mailer.json)
  4. plugin default (backwards compatible)

By default, it will use the exact same output as it originally did,
which preserves backwards-compatibility.

The template should be an absolute path to an ERB template.

An example of a template is here:
https://gist.github.com/joshbeard/d90f2071ed69946c9b58

As a bonus, this commit also allows the timeout interval to be
customized, but defaults to the original '10'