### PR TITLE
Fix check output in mailer template

### DIFF
--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -123,7 +123,7 @@ class Mailer < Sensu::Handler
       template = File.read(message_template)
     else
       template = <<-BODY.gsub(/^\s+/, '')
-        <%= @output %>
+        <%= output %>
         Admin GUI: <%= admin_gui %>
         Host: <%= @event['client']['name'] %>
         Timestamp: <%= Time.at(@event['check']['issued']) %>


### PR DESCRIPTION
Mails generated by handler-mailer.rb do not contain the check output. This PR should fix that.