### PR TITLE
Fix content type selection

### DIFF
--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -84,7 +84,7 @@ class Mailer < Sensu::Handler
             'plain'
           end
 
-    if use.casecmp('html')
+    if use.casecmp('html') == 0
       'text/html; charset=UTF-8'
     else
       'text/plain; charset=ISO-8859-1'


### PR DESCRIPTION
Currently the content type of email messages is always "text/html; charset=UTF-8", regardless of the setting "content_type". This is due to a wrong conditional relying on casecmp. This pull request fixes the issue.