### PR TITLE
Building mailing list from client subscriptions

### DIFF
--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -110,10 +110,19 @@ class Mailer < Sensu::Handler
   def build_mail_to_list
     json_config = config[:json_config]
     mail_to = @event['client']['mail_to'] || settings[json_config]['mail_to']
-    if settings[json_config].key?('subscriptions') && @event['check']['subscribers']
-      @event['check']['subscribers'].each do |sub|
-        if settings[json_config]['subscriptions'].key?(sub)
-          mail_to << ", #{settings[json_config]['subscriptions'][sub]['mail_to']}"
+    if settings[json_config].key?('subscriptions')
+      if @event['check']['subscribers']
+        @event['check']['subscribers'].each do |sub|
+          if settings[json_config]['subscriptions'].key?(sub)
+            mail_to << ", #{settings[json_config]['subscriptions'][sub]['mail_to']}"
+          end
+        end
+      end
+      if @event['client']['subscriptions']
+        @event['client']['subscriptions'].each do |sub|
+          if settings[json_config]['subscriptions'].key?(sub)
+            mail_to << ", #{settings[json_config]['subscriptions'][sub]['mail_to']}"
+          end
         end
       end
     end


### PR DESCRIPTION
Send alerts on client subscriptions.

Given the two "webserver" clients:
```
{
  "client": {
    "name": "i-424242",
    "address": "8.8.8.8",
    "subscriptions": [
      "production",
      "webserver"
    ]
  }
}


{
  "client": {
    "name": "i-424242",
    "address": "8.8.8.8",
    "subscriptions": [
      "development",
      "webserver"
    ]
  }
}
```

And this webserver check:
```
{
  "checks": {
    "chef_client": {
      "command": "/etc/sensu/plugins/check-chef-client.rb",
      "subscribers": [
        "webserver"
      ],
      "interval": 60
    }
  }
}
```

I can register the following mailer configuration and dispatch the alerts to the appropriate mailing list.
```
{
  "mailer": {
    "mail_from": "sensu@example.com",
    "subscriptions": {
      "production": {
        "mail_to": "production-team@example.com"
      },
      "development": {
        "mail_to": "dev-team@example.com"
      }
    }
  }
}
```