### PR TITLE
Add ability to mail based on the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+- Add support to build mailing list based on client name
 
 ## [1.0.0] - 2016-06-23
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The following three configuration variables must be set if you want mailer to us
 
 There is an optional subscriptions hash which can be added to your mailer.json file.  This subscriptions hash allows you to define individual mail_to addresses for a given subscription.  When the mailer handler runs it will check the clients subscriptions and build a mail_to string with the default mailer.mail_to address as well as any subscriptions the client subscribes to where a mail_to address is found.  There can be N number of hashes inside of subscriptions but the key for a given hash inside of subscriptions must match a subscription name. 
 
+In addition there is also an option clients hash which can be added to the mailer.json file. This clients hash allows you to define individual mail_to addresses for a given client. This is to suit cases where a user may want alerts from a particular proxy client, however does not want to receive them for an entire subscription. (This is particularly useful for different aggregate checks that may all share the same 'control' subscription)
+
 Optionally, you can specify your own ERB template file to use for the message
 body.  The order of precedence for templates is: command-line argument (-t),
 client config called "template", the mailer handler config, default.
@@ -39,6 +41,11 @@ client config called "template", the mailer handler config, default.
     "subscriptions": {
       "subscription_name": {
         "mail_to": "teamemail@example.com"
+      }
+    },
+    "clients": {
+      "client_name": {
+        "mail_to": "teamemail2@example.com"
       }
     }
   }

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -126,6 +126,11 @@ class Mailer < Sensu::Handler
         end
       end
     end
+    if settings[json_config].key?('clients')
+      if settings[json_config]['clients'].include?(@event['client']['name'])
+        mail_to << ", #{settings[json_config]['clients'][@event['client']['name']]['mail_to']}"
+      end
+    end
     mail_to
   end
 


### PR DESCRIPTION
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [x] RuboCop passes
#### Purpose

We check a number of aggregates by running a check-aggregate ruby script on our Sensu server against the Sensu API. All these checks use a roundrobin 'control' subscription that the Sensu server is subscribed to; and these checks make use of the proxy client feature to provide a meaningful client name for the check rather than displaying the Sensu server address.

There is a need to be able to alert specifically to different people for different aggregates (and thus different clients). The current scope of this script does not cover our use case (Alerting off the subscription is too broad & with a proxy client it does not have any subscriptions itself).
The proposed change will allow an extra hash in the json config which will be used to build mailing lists off the client name returned in the check data.

**Sample config**

``` json
{
  "mailer": {
    "mail_from": "sensu@example.com",
    "mail_to": "monitor@example.com",
    "smtp_address": "smtp.example.org",
    "smtp_port": "25",
    "smtp_domain": "example.org",
    "template": "/optional/path/to/template.erb",
    "subscriptions": {
      "subscription_name": {
        "mail_to": "teamemail@example.com"
      }
    },
    "clients": {
      "client_name": {
        "mail_to": "teamemail2@example.com"
      }
    }
  }
}
```
#### Known Compatablity Issues

This will not cause any existing compatibility issues, the new block of code will only be executed should a user update their mailer json to include the new key.

Note: This code works but could probably be more elegant so feel free to suggest any improvements.

Cheers.
