### PR TITLE
Revert "Building mailing list from client subscriptions"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- handler-mailer.rb - revert the commit which makes email go to wrong addresses
 
 ## [1.0.0] - 2016-06-23
 ### Fixed

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -110,19 +110,10 @@ class Mailer < Sensu::Handler
   def build_mail_to_list
     json_config = config[:json_config]
     mail_to = @event['client']['mail_to'] || settings[json_config]['mail_to']
-    if settings[json_config].key?('subscriptions')
-      if @event['check']['subscribers']
-        @event['check']['subscribers'].each do |sub|
-          if settings[json_config]['subscriptions'].key?(sub)
-            mail_to << ", #{settings[json_config]['subscriptions'][sub]['mail_to']}"
-          end
-        end
-      end
-      if @event['client']['subscriptions']
-        @event['client']['subscriptions'].each do |sub|
-          if settings[json_config]['subscriptions'].key?(sub)
-            mail_to << ", #{settings[json_config]['subscriptions'][sub]['mail_to']}"
-          end
+    if settings[json_config].key?('subscriptions') && @event['check']['subscribers']
+      @event['check']['subscribers'].each do |sub|
+        if settings[json_config]['subscriptions'].key?(sub)
+          mail_to << ", #{settings[json_config]['subscriptions'][sub]['mail_to']}"
         end
       end
     end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Yes 

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

There is currently an open issue https://github.com/sensu-plugins/sensu-plugins-mailer/issues/32 with email being sent to wrong email addresses. 

#### Known Compatablity Issues


This reverts commit 9e398e1a38c9b3d89db05858805757e8b94d8c4c.