### PR TITLE
Changed mail_to to become a set to remove duplicate addresses.

### DIFF
--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -101,7 +101,7 @@ class Mailer < Sensu::Handler
             'plain'
           end
 
-    if use.casecmp('html') == 0
+    if use.casecmp('html').zero?
       'text/html; charset=UTF-8'
     else
       'text/plain; charset=ISO-8859-1'
@@ -115,11 +115,11 @@ class Mailer < Sensu::Handler
     if settings[json_config].key?('subscriptions') && @event['check']['subscribers']
       @event['check']['subscribers'].each do |sub|
         if settings[json_config]['subscriptions'].key?(sub)
-          mail_to.add("#{settings[json_config]['subscriptions'][sub]['mail_to']}")
+          mail_to.add(settings[json_config]['subscriptions'][sub]['mail_to'].to_s)
         end
       end
     end
-    mail_to.to_a.join(", ")
+    mail_to.to_a.join(', ')
   end
 
   def message_template

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -18,6 +18,7 @@ require 'sensu-handler'
 require 'mail'
 require 'timeout'
 require 'erubis'
+require 'set'
 
 # patch to fix Exim delivery_method: https://github.com/mikel/mail/pull/546
 # #YELLOW
@@ -109,15 +110,16 @@ class Mailer < Sensu::Handler
 
   def build_mail_to_list
     json_config = config[:json_config]
-    mail_to = @event['client']['mail_to'] || settings[json_config]['mail_to']
+    mail_to = Set.new
+    mail_to.add(@event['client']['mail_to'] || settings[json_config]['mail_to'])
     if settings[json_config].key?('subscriptions') && @event['check']['subscribers']
       @event['check']['subscribers'].each do |sub|
         if settings[json_config]['subscriptions'].key?(sub)
-          mail_to << ", #{settings[json_config]['subscriptions'][sub]['mail_to']}"
+          mail_to.add("#{settings[json_config]['subscriptions'][sub]['mail_to']}")
         end
       end
     end
-    mail_to
+    mail_to.to_a.join(", ")
   end
 
   def message_template


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

Unknown

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Changed mail_to to become a set to remove duplicate addresses.
Previously it was generating a to address that contained duplicate addresses:

`bob@bob.com, bob@bob.com, bob@bob.com`

Now, the addresses are entered into a set, and then the to address string generated from the set (has the effect of removing duplicates):

`bob@bob.com`

Hope that makes sensu :-)

#### Known Compatablity Issues

Unknown
