### PR TITLE
Add NTLM auth options via dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ client config called "template", the mailer handler config, default.
   }
 }
 ```
+By default, the handler will use `plain` as the SMTP authentication type, but you may also specify `"smtp_authentication": "ntlm"` for compatible servers, e.g. Microsoft Exchange.
 
 ## Installation
 

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -19,6 +19,7 @@ require 'mail'
 require 'timeout'
 require 'erubis'
 require 'set'
+require 'ntlm/smtp'
 
 # patch to fix Exim delivery_method: https://github.com/mikel/mail/pull/546
 # #YELLOW

--- a/sensu-plugins-mailer.gemspec
+++ b/sensu-plugins-mailer.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'mailgun-ruby',      '1.0.3'
   s.add_runtime_dependency 'sensu-plugin',      '~> 1.2'
   s.add_runtime_dependency 'erubis',            '2.7.0'
+  s.add_runtime_dependency 'ruby-ntlm',         '0.0.3'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No
#### General
- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
- [x] Binstubs are created if needed
- [x] RuboCop passes -- It passes as far as it introduces no new errors.
- [x] Existing tests pass 
#### New Plugins
- [ ] Tests
- [ ] Add the plugin to the README
- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)
#### Purpose

Our corporate server is a hosted Exchange 2010 that only supports NTLM auth. Adding ruby-ntlm as a dependency allows the use of `"smtp_authentication": "ntlm"` in the mailer.json to successfully authenticate. This took me the better part of a day to figure out, so I feel other admins new to Sensu could benefit from OOB experience.
#### Known Compatablity Issues
