### PR TITLE
Adding Contact Routing the way Sensu Enterprise does it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Fixed
 - handler-mailer.rb - revert the commit which makes email go to wrong addresses
 
+### Added
+- handler-mailer.rb: add contact routing like Sensu Enterprise works 
+
 ## [1.0.0] - 2016-06-23
 ### Fixed
 - fix timeout deprecation for ruby 2.3.0

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Optionally, this handler can use the same syntax as [Sensu Enterprise contact ro
 } 
 ```
 
-Then, in a check defination, you can specify a contact or an array of contacts which should be notified by e-mail:
+Then, in a check definition, you can specify a contact or an array of contacts which should be notified by e-mail:
 
 **example_check.json**
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,40 @@ client config called "template", the mailer handler config, default.
 }
 ```
 
+### Contact Based Routing
+
+Optionally, this handler can use the same syntax as [Sensu Enterprise contact routing](https://sensuapp.org/docs/0.26/enterprise/contact-routing.html) for sending e-mails for particular checks or clients, in addition to the previous configuration. This is configured by declaring contacts:
+
+**support.json**
+```
+{
+  "contacts": {
+    "support": {
+      "email": {
+        "to": "support@sensuapp.com"
+      }
+    }
+  }
+} 
+```
+
+Then, in a check defination, you can specify a contact or an array of contacts which should be notified by e-mail:
+
+**example_check.json**
+```
+{
+  "checks": {
+    "example_check": {
+      "command": "do_something.rb",
+      "handler": "mailer",
+      "contact": "support"
+    }
+  }
+}
+```
+
+Additionally, a client defination can specify a contact or an array of contacts to be notified of any check which alerts to the mailer handler. This is configured by specifying a contact value, or contacts array in the client.json configuration.
+
 ## Installation
 
 [Installation and Setup](http://sensu-plugins.io/docs/installation_instructions.html)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Then, in a check definition, you can specify a contact or an array of contacts w
 }
 ```
 
-Additionally, a client defination can specify a contact or an array of contacts to be notified of any check which alerts to the mailer handler. This is configured by specifying a contact value, or contacts array in the client.json configuration.
+Additionally, a client definition can specify a contact or an array of contacts to be notified of any check which alerts to the mailer handler. This is configured by specifying a contact value, or contacts array in the client.json configuration.
 
 ## Installation
 

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -119,6 +119,22 @@ class Mailer < Sensu::Handler
         end
       end
     end
+    if settings.key?('contacts')
+      all_contacts = []
+      for field in ['check', 'client']
+        if @event[field].key?('contact')
+          all_contacts << @event[field]['contact']
+        end
+        if @event[field].key?('contacts')
+          all_contacts += @event[field]['contacts']
+        end
+      end
+      all_contacts.each do |sub|
+        if settings['contacts'].key?(sub)
+          mail_to.add(settings['contacts'][sub]['email']['to'].to_s)
+        end
+      end
+    end
     mail_to.to_a.join(', ')
   end
 

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -121,7 +121,7 @@ class Mailer < Sensu::Handler
     end
     if settings.key?('contacts')
       all_contacts = []
-      for field in ['check', 'client']
+      %w(check client).each do |field|
         if @event[field].key?('contact')
           all_contacts << @event[field]['contact']
         end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** [Yes](https://github.com/sensu-plugins/sensu-plugins-mailer/issues/23)

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Add ability to configure particular checks or clients to e-mail different contacts, similar to the existing [Sensu Enterprise contact routing](https://sensuapp.org/docs/0.26/enterprise/contact-routing.html) usage

#### Known Compatablity Issues

