### PR TITLE
handler-mailer.rb needs the name of the JSON configuration block

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Create a handler file in `/etc/sensu/conf.d` with the following content, replaci
     "handlers": {
         "mailer": {
             "type": "pipe",
-            "command": "/opt/sensu/embedded/bin/handler-mailer.rb"
+            "command": "/opt/sensu/embedded/bin/handler-mailer.rb -j mailer"
         }
     }
 }


### PR DESCRIPTION
    -j, --json_config JsonConfig     Name of the JSON Configuration block in Sensu

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
