### PR TITLE
Display default key in help message

### DIFF
--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -36,7 +36,7 @@ end
 
 class Mailer < Sensu::Handler
   option :json_config_name,
-         description: 'Name of the JSON Configuration block in Sensu',
+         description: 'Name of the JSON Configuration block in Sensu (default: mailer)',
          short: '-j JsonConfig',
          long: '--json_config JsonConfig',
          required: false,


### PR DESCRIPTION
Related to discussion here https://github.com/sensu-plugins/sensu-plugins-mailer/issues/45#issuecomment-326268849

## Pull Request Checklist

https://github.com/sensu-plugins/sensu-plugins-mailer/issues/45#issuecomment-326268849

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
