### PR TITLE
Feature/unknown on passing contacts to contact

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 #### General
 
-- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
+- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 - [ ] Update README with any necessary configuration snippets
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,20 @@
-#Change Log
+# Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
+This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Breaking Change
+- handler-mailer.rb: emit an `unknown` with a helpful message when trying to configure `settings['contact']` with multiple objects. This helps avoid confusion over using `contact` when you meant `contacts`. (@majormoses)
+
 ### Added
 - ruby 2.4 testing in travis. (@majormoses)
 - handler-mailer.rb: added default key in description (@arthurlogilab)
 
 ### Fixed
 - PR template spell "Compatibility" correctly (@majormoses)
+- update changelog guideline location (@majormoses)
 
 ## [1.2.0] - 2017-06-24
 ### Added

--- a/bin/handler-mailer.rb
+++ b/bin/handler-mailer.rb
@@ -145,7 +145,13 @@ class Mailer < Sensu::Handler
         end
       end
     end
-    if settings.key?('contacts')
+    if settings.key?('contact') && settings['contact'].is_a?(Array)
+      msg = "you passed #{settings['contact']} which is meant to be a string, "
+      msg += 'if you need more than one contact you can use `contacts` to '
+      msg += 'configure multiple recipients'
+      p msg
+      exit 3 # unknown
+    elsif settings.key?('contacts')
       all_contacts = []
       %w(check client).each do |field|
         if @event[field].key?('contact')


### PR DESCRIPTION
## Pull Request Checklist

#58 

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Provide user with better feedback when improperly using `contact` rather than `contacts` when passing multiple contacts.
#### Known Compatibility Issues
Anyone who is using it currently incorrectly will have start alerting them to their misconfiguration. I feel the benefit outweighs the negative as it informs them exactly what needs to change and if they pull in a major version without reading the changelog that is on them.