### PR TITLE
improve error handling for `contact` vs `contacts` in event data:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Fixed
+- handler-mailer.rb: emit an `unknown` with a helpful message when receiving an event `@event['contact']` with multiple objects in an array. This helps avoid confusion over using `contact` when you meant `contacts`. (@majormoses)
+
 ## [2.0.0] - 2017-10-21
 ### Breaking Change
 - handler-mailer.rb: emit an `unknown` with a helpful message when trying to configure `settings['contact']` with multiple objects. This helps avoid confusion over using `contact` when you meant `contacts`. (@majormoses)


### PR DESCRIPTION
when an event has a payload with `contact` and it is an array we should bail and present the user with a useful error message.

#58 

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass


#### Purpose
Previously we attempted to catch when the user had settings of `contact` with an array, adding the same checking on event data as it can be specified with a check.
#### Known Compatibility Issues
