### PR TITLE
Bumping sensu-plugin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Breaking Changes
+- bumped dependency of `sensu-plugin` to 2.x you can read about it  [here](https://github.com/sensu-plugins/sensu-plugin/blob/master/CHANGELOG.md#v145---2017-03-07) (@majormoses)
+
 ## [2.1.0] - 2018-11-01
 ### Added
 - handler-mailer.rb: add subject_template feature. With this option to can change the default subject with a template.

--- a/sensu-plugins-mailer.gemspec
+++ b/sensu-plugins-mailer.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-ses',           '0.6.0'
   s.add_runtime_dependency 'mail',              '2.6.3'
   s.add_runtime_dependency 'mailgun-ruby',      '1.0.3'
-  s.add_runtime_dependency 'sensu-plugin',      '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',      '~> 2.7'
   s.add_runtime_dependency 'erubis',            '2.7.0'
   s.add_runtime_dependency 'ruby-ntlm',         '0.0.3'
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#78 , #45 

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
See details in #78 . Handler does its own filtering. Bumping up the gem resolves this. 

#### Known Compatibility Issues
This is bumping up to 2.X, likely a breaking change. 